### PR TITLE
Fix the issue of handling empty credentials in the __init__ method.

### DIFF
--- a/threads/apis/private.py
+++ b/threads/apis/private.py
@@ -43,7 +43,7 @@ class PrivateThreadsApi(AbstractThreadsApi):
                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
             }
 
-        self.user_id = self.get_user_id(username=username)
+            self.user_id = self.get_user_id(username=username)
 
     def _get_instagram_api_token(self):
         """

--- a/threads/apis/private.py
+++ b/threads/apis/private.py
@@ -27,13 +27,13 @@ class PrivateThreadsApi(AbstractThreadsApi):
         """
         super().__init__()
 
-        self.username = username
-        self.password = password
+        if username is not None and password is not None:
+            self.username = username
+            self.password = password
 
-        self.timezone_offset = -14400
-        self.android_device_id = generate_android_device_id()
+            self.timezone_offset = -14400
+            self.android_device_id = generate_android_device_id()
 
-        if self.username is not None and self.password is not None:
             self.instagram_api_token = self._get_instagram_api_token()
 
             self.headers = {
@@ -43,7 +43,13 @@ class PrivateThreadsApi(AbstractThreadsApi):
                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
             }
 
-            self.user_id = self.get_user_id(username=username)
+            self.user_id = self.get_user_id(username=self.username)
+        else:
+            self.timezone_offset = None
+            self.android_device_id = None
+            self.instagram_api_token = None
+            self.headers = None
+            self.user_id = None
 
     def _get_instagram_api_token(self):
         """

--- a/threads/apis/public.py
+++ b/threads/apis/public.py
@@ -53,7 +53,7 @@ class PublicThreadsApi(AbstractThreadsApi):
             headers=self.fetch_html_headers,
         )
 
-        token_key_value = re.search('LSD",\[\],{"token":"(\w+)"},\d+\]', response.text).group()
+        token_key_value = re.search('LSD",\[\],{"token":"(.*?)"},\d+\]', response.text).group()
         token_key_value = token_key_value.replace('LSD",[],{"token":"', '')
         token = token_key_value.split('"')[0]
 


### PR DESCRIPTION
In the __init__ method, added a check to handle the case when the username and password are not provided. If either of them is missing, the relevant parameters are set to None, preventing any errors during API calls. This ensures the code can continue execution smoothly even without the private API login credentials.