### PR TITLE
Add download_settings_with_new_token method

### DIFF
--- a/threads/apis/private.py
+++ b/threads/apis/private.py
@@ -80,6 +80,10 @@ class PrivateThreadsApi(AbstractThreadsApi):
 
         self.user_id = self.get_user_id(username=username)
 
+    def renew_instagram_api_token(self: PrivateThreadsApi) -> str:
+        self.instagram_api_token = self._get_instagram_api_token()
+        return self.instagram_api_token
+
     def get_user_id(self: PrivateThreadsApi, username: str) -> int:
         """
         Get a user's identifier.

--- a/threads/main.py
+++ b/threads/main.py
@@ -42,13 +42,17 @@ class Threads:
         self.public_api = PublicThreadsApi()
         self.private_api = PrivateThreadsApi(settings=self.settings, username=username, password=password)
 
-    def download_settings(self: Threads, path: str) -> None:
+    def download_settings(self: Threads, path: str, renew_token: bool = False) -> None:
         """
         Download settings.
 
         Arguments:
             path (str): a path to a JSON file.
+            renew_token (bool): whether to renew the authentication token.
         """
+        if renew_token:
+            self.private_api.renew_instagram_api_token()
+
         self.settings.download_settings(
             path=path,
             authentication_token=self.private_api.instagram_api_token,

--- a/threads/main.py
+++ b/threads/main.py
@@ -42,18 +42,26 @@ class Threads:
         self.public_api = PublicThreadsApi()
         self.private_api = PrivateThreadsApi(settings=self.settings, username=username, password=password)
 
-    def download_settings(self: Threads, path: str, renew_token: bool = False) -> None:
+    def download_settings(self: Threads, path: str) -> None:
         """
         Download settings.
 
         Arguments:
             path (str): a path to a JSON file.
-            renew_token (bool): whether to renew the authentication token.
         """
-        if renew_token:
-            self.private_api.renew_instagram_api_token()
-
         self.settings.download_settings(
             path=path,
             authentication_token=self.private_api.instagram_api_token,
+        )
+    
+    def download_settings_with_new_token(self: Threads, path: str) -> None:
+        """
+        Download settings with a new authentication token.
+
+        Arguments:
+            path (str): a path to a JSON file.
+        """
+        self.settings.download_settings(
+            path=path,
+            authentication_token=self.private_api.renew_instagram_api_token(),
         )


### PR DESCRIPTION
solved this issue : https://github.com/dmytrostriletskyi/threads-net/issues/57

Added download_settings_with_new_token method to avoid receiving e-mail below from instagram.
```
We noticed a login from a device you don't usually use.
 
If this was you, you won’t be able to access certain security and account settings for a few days. You can still access these settings from a device you’ve logged in with in the past
```

Now, download_settings method is using cached authentication_token. but, when it was expired, constructer is need to called without Settings option. Then, device_id and other params are not taken over.
So, I added download_settings_with_new_token method.
This may be able to reduce the suspection from instagram caused by device id's difference.